### PR TITLE
Added missing permissions for Atmosphere

### DIFF
--- a/portlets/whiteboard-portlet/docroot/WEB-INF/liferay-plugin-package.properties
+++ b/portlets/whiteboard-portlet/docroot/WEB-INF/liferay-plugin-package.properties
@@ -40,7 +40,10 @@ security-manager-properties-read=\
     org.glassfish.web.rfc2109_cookie_names_enforced,\
     os.arch,\
     os.name,\
-    os.version
+    os.version,\
+    org.apache.catalina.STRICT_SERVLET_COMPLIANCE,\
+	org.apache.tomcat.util.http.ServerCookie.STRICT_NAMING,\
+	org.apache.tomcat.util.http.ServerCookie.FWD_SLASH_IS_SEPARATOR
     
 security-manager-properties-write=\
     org.apache.catalina.STRICT_SERVLET_COMPLIANCE


### PR DESCRIPTION
The new three permissions are needed by Atmosphere Framework to work
properly with Security Manager enabled in Tomcat.